### PR TITLE
Publish snapshots via ./gradlew artifactoryPublish

### DIFF
--- a/converters/build.gradle
+++ b/converters/build.gradle
@@ -26,8 +26,8 @@ buildscript {
     }
 
     dependencies {
-//        classpath 'com.github.jruby-gradle:jruby-gradle-plugin:1.1.4'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:3.1.1"
+        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.0.0"
     }
 }
 
@@ -42,22 +42,24 @@ repositories {
     }
 }
 
+group = 'org.asciidoctor'
+version = '0.1'
+
+if(!project.properties.RELEASE) {
+    version = "${version}-SNAPSHOT"
+}
+
+apply plugin : 'maven-publish'
 apply plugin : 'groovy'
 //apply plugin : 'com.github.jruby-gradle.base'
 apply plugin : 'com.jfrog.artifactory'
-apply plugin : 'maven'  // TODO: Goto maven-publish
 
 archivesBaseName = 'asciidoctor-leanpub-markdown'
-group = 'org.asciidoctor'
-version = '0.1'
 
 ext {
     asciidoctorjVersion = '1.6.0-SNAPSHOT'
 }
 
-if(!project.properties.RELEASE) {
-    version = "${version}-SNAPSHOT"
-}
 
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
@@ -85,6 +87,7 @@ dependencies {
     testCompile('org.spockframework:spock-core:1.0-groovy-2.3') {
         exclude(module: 'groovy-all')
     }
+    testCompile "org.jruby:jruby:9.1.2.0"
     testRuntime 'org.asciidoctor:asciidoctorj-diagram:1.3.1'
     testRuntime 'org.slf4j:slf4j-simple:1.7.5'
 }
@@ -123,7 +126,8 @@ artifactory {
         }
         defaults {
 
-//                publications('mavenNebula')
+            publications('jars')
+            publicConfigs('archives')
 
             def dryRun = project.hasProperty('dryRun') && project.dryRun.toBoolean()
             publishBuildInfo = !dryRun  //Publish build-info to Artifactory (true by default)
@@ -138,5 +142,15 @@ artifactory {
 
 artifactoryPublish{
     onlyIf { version.endsWith('-SNAPSHOT') }
-//    dependsOn preparePublish
+}
+
+publishing.publications {
+    jars(MavenPublication) {
+        artifactId 'asciidoctor-leanpub-markdown'
+
+        artifact sourcesJar
+        artifact javadocJar
+
+        from components.java
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip


### PR DESCRIPTION
With this PR snapshots can be published anytime to oss.jfrog.org via `./gradlew artifactoryPublish -i`.

`bintrayUsername` and `bintrayApiKey` have to be set appropriately.

I already published a first snapshot that is available here: https://oss.jfrog.org/artifactory/webapp/#/artifacts/browse/simple/General/oss-snapshot-local/org/asciidoctor/asciidoctor-leanpub-markdown/0.1-SNAPSHOT
