### PR TITLE
Setup publishing policy for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 jdk:
   - oraclejdk8
 install: true
-script: ./gradlew -S -Pskip.signing build artifactoryPublish
+script: ./gradlew -S -Pskip.signing build artifactoryPublish publish
 notifications:
   email: false
   irc:

--- a/converters/build.gradle
+++ b/converters/build.gradle
@@ -158,10 +158,6 @@ artifactory {
 
 }
 
-artifactoryPublish{
-    onlyIf { !version.endsWith('-SNAPSHOT') }
-    dependsOn build
-}
 
 publishing.publications {
     jars(MavenPublication) {
@@ -212,7 +208,24 @@ jar {
     }
 }
 
+artifactoryPublish{
+    onlyIf { !version.endsWith('-SNAPSHOT') }
+    dependsOn build
+}
+
+publish {
+    onlyIf { version.endsWith('-SNAPSHOT') }
+    dependsOn build
+}
+
 travisci {
+
+    ext {
+        travisPublishStatus = ( System.getenv('TRAVIS_BRANCH') == 'master' &&
+            System.getenv('TRAVIS_REPO_SLUG') == 'asciidoctor/asciidoctor-leanpub-converter' &&
+            System.getenv('TRAVIS_PULL_REQUEST') == 'false' &&
+            System.getenv('TRAVIS_JDK_VERSION') == 'oraclejdk8' )
+    }
 
     task travisParams {
         doLast {
@@ -221,11 +234,12 @@ travisci {
             }
         }
     }
-    artifactoryPublish.dependsOn travisParams
 
-    artifactoryPublish.enabled = ( System.getenv('TRAVIS_BRANCH') == 'master' &&
-        System.getenv('TRAVIS_REPO_SLUG') == 'asciidoctor/asciidoctor-leanpub-converter' &&
-        System.getenv('TRAVIS_PULL_REQUEST') == 'false' &&
-        System.getenv('TRAVIS_JDK_VERSION') == 'oraclejdk8' )
+    artifactoryPublish.dependsOn travisParams
+    publish.dependsOn travisParams
+
+    artifactoryPublish.enabled = travisPublishStatus
+    publish.enabled = travisPublishStatus
+
 }
 


### PR DESCRIPTION
- Publish to Bintray only when not a SNAPSHOT.
- Publish to OSS Artifactory only when a SNAPSHOT.
- Only publish from master when not a PR and when JDK is being used.
- Only publish from asciidoctor repository and not any clone repositories.