### PR TITLE
Publish to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,23 @@
 //}
 
 plugins {
-    id 'com.jfrog.artifactory' version '4.9.6' apply false
-    id 'com.jfrog.bintray' version '1.8.4' apply false
+    id "signing"
+    id "io.codearte.nexus-staging" version "0.22.0"
+    id "de.marcphilipp.nexus-publish" version "0.4.0"
     id 'org.ysb33r.cloudci' version '2.5'
+}
+
+apply plugin: 'io.codearte.nexus-staging'
+
+
+nexusStaging {
+    if (project.hasProperty("sonatypeUsername")) {
+        username = project.sonatypeUsername
+    }
+    if (project.hasProperty("sonatypePassword")) {
+        password = project.sonatypePassword
+    }
+    repositoryDescription = "Release ${project.group} ${project.version}"
 }
 
 allprojects {
@@ -45,7 +59,7 @@ allprojects {
 subprojects {
 
     repositories {
-        jcenter()
+        mavenCentral()
         if (version.endsWith('-SNAPSHOT')) {
             maven {
                 name 'Asciidoctor Snapshots'

--- a/converters/build.gradle
+++ b/converters/build.gradle
@@ -19,12 +19,7 @@
 
 apply plugin: 'groovy'
 apply plugin: 'java-library'
-apply plugin: 'com.jfrog.artifactory'
-apply plugin: 'com.jfrog.bintray'
-
-// NOTE replace deficient built-in publishing plugin with nebula-publishing,
-// which does a better job generating the POM and properly aggregates signature files for upload to Bintray
-apply plugin: 'maven-publish'
+apply plugin: 'de.marcphilipp.nexus-publish'
 
 ext {
 
@@ -104,122 +99,65 @@ test {
     systemProperties 'TESTROOT': file("${buildDir}/test/leanpub")
 }
 
-task sourcesJar(type: Jar, dependsOn: classes, group: 'Release') {
-    description 'Assembles a jar archive containing the main source code.'
-    from sourceSets.main.allSource
-    classifier 'sources'
+java {
+    withSourcesJar()
+    withJavadocJar()
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc, group: 'Release') {
-    description 'Assembles a jar archive containing the Javadoc API documentation for the main source code.'
-    from javadoc.destinationDir
-    classifier 'javadoc'
-}
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+            artifactId 'asciidoctor-leanpub-markdown'
 
-artifacts {
-    archives sourcesJar, javadocJar
-}
-
-artifactory {
-    contextUrl = 'https://oss.jfrog.org/artifactory'
-    //The base Artifactory URL if not overridden by the publisher/resolver
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = project.hasProperty('bintrayUsername') ? project.bintrayUsername : ''
-            password = project.hasProperty('bintrayApiKey') ? project.bintrayApiKey : ''
-            maven = true
-        }
-        defaults {
-
-            publications('jars')
-            publicConfigs('archives')
-
-            publishBuildInfo = !dryRunPublications  //Publish build-info to Artifactory (true by default)
-            publishArtifacts = !dryRunPublications   //Publish artifacts to Artifactory (true by default)
-            publishPom = !dryRunPublications  //Publish generated POM files to Artifactory (true by default).
-            publishIvy = false   //Publish generated Ivy descriptor files to Artifactory (true by default).
-
+            pom.withXml {
+                asNode().children().last() + projectMeta
+            }
         }
     }
 
-}
-
-bintray {
-    user = project.hasProperty('bintrayUsername') ? project.bintrayUsername : ''
-    key = project.hasProperty('bintrayApiKey') ? project.bintrayApiKey : ''
-
-    publications = ['jars']
-
-//    if ( !project.hasProperty('skip.signing') ) {
-//        // Copy the signed pom to bintrayDestination
-//        filesSpec {
-//            from signPom
-//            into signPom.bintrayDestination
-//        }
-//        bintrayUpload.dependsOn signPom
-//    }
-
-    dryRun = project.hasProperty('dryRun') && project.dryRun.toBoolean()
-    publish = !version.endsWith('-SNAPSHOT')
-
-    pkg {
-        repo = System.env['BINTRAY_REPO'] ?: (project.hasProperty('bintrayRepo') ? project.bintrayRepo : 'maven')
-        userOrg = 'asciidoctor'
-        name = 'asciidoctor-leanpub-backend'
-        desc = project.description
-
-        licenses = ['Apache-2.0']
-        labels = ['asciidoctor', 'asciidoctorj', 'asciidoc']
-        websiteUrl = 'http://asciidoctor.org/docs/asciidoctorj'
-        issueTrackerUrl = 'https://github.com/asciidoctor/asciidoctor-leanpub-converter/issues'
-        vcsUrl = 'https://github.com/asciidoctor/asciidoctor-leanpub-converter'
-        publicDownloadNumbers = true
-
-        version {
-            name = project.version
-            vcsTag = "${rootProject.name}-${rootProject.version}"
+    repositories {
+        maven {
+            name = "local"
+            def releasesRepoUrl = "$buildDir/repos/releases"
+            def snapshotsRepoUrl = "$buildDir/repos/snapshots"
+            url = version.endsWith("SNAPSHOT") ? snapshotsRepoUrl : releasesRepoUrl
         }
     }
 }
 
-
-publishing.publications {
-    jars(MavenPublication) {
-        artifactId 'asciidoctor-leanpub-markdown'
-
-        artifact sourcesJar
-        artifact javadocJar
-
-        from components.java
-
-        pom.withXml {
-            asNode().children().last() + projectMeta
+nexusPublishing {
+    repositories {
+        sonatype {
+            if (project.hasProperty("sonatypeUsername")) {
+                username = project.sonatypeUsername
+            }
+            if (project.hasProperty("sonatypePassword")) {
+                password = project.sonatypePassword
+            }
         }
     }
 }
 
-//if ( !project.hasProperty('skip.signing') ) {
-//    task addSignaturesToPublication(dependsOn: signArchives) {
-//        group "publishing"
-//        description "add all signatures to the publication"
-//
-//        doLast {
-//            publishing.publications {
-//                jars(MavenPublication) {
-//                    configurations.signatures.getArtifacts().each { sig ->
-//                        logger.debug "adding signature to jars publication: $sig"
-//                        artifact(sig) {
-//                            extension "jar.asc"
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//
-//    tasks["signPom"].finalizedBy addSignaturesToPublication
-//}
+def hasSigningKey = project.hasProperty("signing.keyId") || project.findProperty("signingKey")
+if(hasSigningKey && !project.hasProperty('skip.signing')) {
+    apply plugin: 'signing'
+    sign(project)
+}
+void sign(Project project) {
+    project.signing {
+        required { project.gradle.taskGraph.hasTask("required") }
+        def signingKeyId = project.findProperty("signingKeyId")
+        def signingKey = project.findProperty("signingKey")
+        def signingPassword = project.findProperty("signingPassword")
+        if (signingKeyId) {
+            useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+        } else if (signingKey) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+        }
+        sign publishing.publications.maven
+    }
+}
 
 jar {
     manifest {
@@ -230,21 +168,6 @@ jar {
             'Implementation-Version': project.version,
             'Implementation-Vendor': 'asciidoctor.org'
     }
-}
-
-artifactoryPublish {
-    onlyIf { version.endsWith('-SNAPSHOT') }
-    dependsOn build
-}
-
-publish {
-    onlyIf { !version.endsWith('-SNAPSHOT') }
-    dependsOn build
-}
-
-bintrayUpload {
-    onlyIf { !version.endsWith('-SNAPSHOT') }
-    dependsOn build
 }
 
 ci {
@@ -272,10 +195,6 @@ ci {
             Task t = tasks.getByName(it)
             t.dependsOn travisParams
             t.enabled = travisAllowPublish || travisAllowDryRun
-        }
-
-        bintray {
-            dryRun = travisAllowDryRun
         }
 
         artifactory {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the build to publish to Maven central instead of jcenter.
I more or less followed the description from https://github.com/rwinch/gradle-publish-ossrh-sample

To build a release follow these steps:

1. Build the release with
  ```
  # ./gradlew clean build
  ```
2. After testing publish all artifacts to a local repository under converters/build/repos with
  ```
  ./gradlew publishAllPublicationsToLocalRepository -i
  ```
3. When everything is fine publish the artifacts to a staging repository on https://oss.sonatype.org and close the repository:
  ```
  # ./gradlew publishAllPublicationsToSonatypeRepository -i
  # ./gradlew closeRepository -i
  ```
4. Visit https://oss.sonatype.org/#stagingRepositories and check the staging repository. The artifacts are not published yet.   The repository URL shown there can be used for testing this version before publishing to Maven central.
5. When everything is fine publish the artifacts in the staging repository by clicking the "Release" button. Alternatively you can release it with
  ```
  # ./gradlew releaseRepository
  ```

I uploaded the artifacts with this PR to https://oss.sonatype.org/content/repositories/orgasciidoctor-1242.

There might be some more cleanup possible.
I am not too familiar with the travisci plugin, so it might be necessary to clean that up as well.


